### PR TITLE
People Page images hot fix

### DIFF
--- a/style.scss
+++ b/style.scss
@@ -55,8 +55,8 @@ body {
   margin: 30px 20px 0px 20px;
   justify-content: center;
   @include mobile {
-    width: 0;
-    flex: 0;
+    width: 100px;
+    flex: 1;
   }
 }
 


### PR DESCRIPTION
Changed the style used for images on people page so that they do not disappear on mobile platforms. This new version will keep the images at a fixed width of 100px on mobile platforms. 